### PR TITLE
feat: 加强版枚举工具

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "abortcontroller-polyfill": "^1.7.8",
     "alova": "^3.3.3",
     "dayjs": "1.11.10",
+    "enum-plus": "2.3.3",
     "js-cookie": "^3.0.5",
     "pinia": "2.0.36",
     "pinia-plugin-persistedstate": "3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       dayjs:
         specifier: 1.11.10
         version: 1.11.10
+      enum-plus:
+        specifier: 2.3.3
+        version: 2.3.3
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1226,6 +1229,7 @@ packages:
   '@esbuild/darwin-arm64@0.20.2':
     resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
     engines: {node: '>=12'}
+    cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-arm64@0.25.5':
@@ -1237,6 +1241,7 @@ packages:
   '@esbuild/darwin-x64@0.20.2':
     resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
@@ -2007,6 +2012,7 @@ packages:
 
   '@rollup/rollup-darwin-x64@4.28.0':
     resolution: {integrity: sha512-8hxgfReVs7k9Js1uAIhS6zq3I+wKQETInnWQtgzt8JfGx51R1N6DRVy3F4o0lQwumbErRz52YqwjfvuwRxGv1w==}
+    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.41.1':
@@ -3458,6 +3464,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  enum-plus@2.3.3:
+    resolution: {integrity: sha512-vpkBNsuoE6eI723oMrjFtEaVe1wqlMbzhH49hXIB4fog86NFrTHNkvNqa5IQiC49Y/QfrfGTmI3pNpoAL8RhSg==}
+    engines: {node: '>=7.10.1'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -10776,6 +10786,8 @@ snapshots:
       tapable: 2.2.1
 
   entities@4.5.0: {}
+
+  enum-plus@2.3.3: {}
 
   env-paths@2.2.1: {}
 

--- a/src/enums/baseEnum.ts
+++ b/src/enums/baseEnum.ts
@@ -1,0 +1,63 @@
+/**
+ * 基础枚举
+ * 与业务无关
+ * @author cnguu
+ */
+
+import { enumUtil } from '@/utils/enumUtil'
+
+/** 约定俗成的二极管 字符串型 */
+export const FlagStringEnum = enumUtil({
+  /** 是 */
+  TRUE: {
+    value: '1',
+    label: '是',
+  },
+  /** 否 */
+  FALSE: {
+    value: '0',
+    label: '否',
+  },
+} as const)
+
+/** 约定俗成的二极管 数字型 */
+export const FlagNumberEnum = enumUtil({
+  /** 是 */
+  TRUE: {
+    value: 1,
+    label: '是',
+  },
+  /** 否 */
+  FALSE: {
+    value: 0,
+    label: '否',
+  },
+} as const)
+
+/** 约定俗成的二极管 布尔型 */
+export const FlagBooleanEnum = enumUtil({
+  /** 是 */
+  TRUE: {
+    value: true,
+    label: '是',
+  },
+  /** 否 */
+  FALSE: {
+    value: false,
+    label: '否',
+  },
+} as const)
+
+/** 性别 */
+export const SexEnum = enumUtil({
+  /** 男 */
+  MAN: {
+    value: '1',
+    label: '男',
+  },
+  /** 女 */
+  WOMAN: {
+    value: '2',
+    label: '女',
+  },
+} as const)

--- a/src/utils/enumUtil.ts
+++ b/src/utils/enumUtil.ts
@@ -1,0 +1,8 @@
+/**
+ * 枚举工具
+ * @author cnguu
+ */
+import { Enum } from 'enum-plus'
+
+/** 加强版 enum */
+export const enumUtil = Enum


### PR DESCRIPTION
加强枚举功能性，快速转换业务需要的数据格式

- 项目枚举统一管理：`src/enums`
- 文件名规范：小写开头驼峰，Enum结尾
- 使用示例：
  ```typescript
  import { SexEnum } from "@/enums/baseEnum.ts"
  
  // 当前性别值
  const sexState = ref<typeof SexEnum.valueType>(SexEnum.MAN)
  
  // 性别选项
  const sexOptions = SexEnum.items
  ```