### PR TITLE
feat: 允许仅通过b-[pos]-[size]来向元素添加边框

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -17,3 +17,18 @@ page {
   // 修改按钮背景色
   // --wot-button-primary-bg-color: green;
 }
+
+/*
+由于uniapp中无法使用*选择器，使用魔法代替*，加上此规则可以简化border与divide的使用，并提升布局的兼容性
+1. 防止padding和border影响元素宽度。 (https://github.com/mozdevs/cssremedy/issues/4)
+2. 允许仅通过添加边框宽度来向元素添加边框。 (https://github.com/tailwindcss/tailwindcss/pull/116)
+3. [UnoCSS]: 允许使用css变量'--un-default-border-color'覆盖默认边框颜色
+*/
+:not(not),
+::before,
+::after {
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+  border-color: var(--un-default-border-color, #e5e7eb); /* 3 */
+}


### PR DESCRIPTION
由于uniapp中无法使用*选择器，使用魔法代替*，加上此规则可以简化border与divide的使用，并提升布局的兼容性  
1. 防止padding和border影响元素宽度。 (https://github.com/mozdevs/cssremedy/issues/4)  
2. 允许仅通过添加边框宽度来向元素添加边框。 (https://github.com/tailwindcss/tailwindcss/pull/116)  
3. 允许使用css变量'--un-default-border-color'覆盖默认边框颜色