### PR TITLE
feat(typings): 补全 uni.hideToast() 和 uni.hideLoading() 的 options 类型

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -30,4 +30,116 @@ declare global {
   }
 }
 
+// patch uni 类型
+// 1. 补全 uni.hideToast() 的 options 类型
+// 2. 补全 uni.hideLoading() 的 options 类型
+declare global {
+  declare namespace UniNamespace {
+    /** 接口调用结束的回调函数（调用成功、失败都会执行） */
+    type HideLoadingCompleteCallback = (res: GeneralCallbackResult) => void
+    /** 接口调用失败的回调函数 */
+    type HideLoadingFailCallback = (res: GeneralCallbackResult) => void
+    /** 接口调用成功的回调函数 */
+    type HideLoadingSuccessCallback = (res: GeneralCallbackResult) => void
+
+    interface HideLoadingOption {
+      /** 接口调用结束的回调函数（调用成功、失败都会执行） */
+      complete?: HideLoadingCompleteCallback
+      /** 接口调用失败的回调函数 */
+      fail?: HideLoadingFailCallback
+      test: UniNamespace.GeneralCallbackResult
+      /**
+       * 微信小程序：需要基础库： `2.22.1`
+       *
+       * 微信小程序：目前 toast 和 loading 相关接口可以相互混用，此参数可用于取消混用特性
+       */
+      noConflict?: boolean
+      /** 接口调用成功的回调函数 */
+      success?: HideLoadingSuccessCallback
+    }
+
+    // ----------------------------------------------------------
+
+    /** 接口调用结束的回调函数（调用成功、失败都会执行） */
+    type HideToastCompleteCallback = (res: GeneralCallbackResult) => void
+    /** 接口调用失败的回调函数 */
+    type HideToastFailCallback = (res: GeneralCallbackResult) => void
+    /** 接口调用成功的回调函数 */
+    type HideToastSuccessCallback = (res: GeneralCallbackResult) => void
+    interface HideToastOption {
+      /** 接口调用结束的回调函数（调用成功、失败都会执行） */
+      complete?: HideToastCompleteCallback
+      /** 接口调用失败的回调函数 */
+      fail?: HideToastFailCallback
+      /**
+       * 微信小程序：需要基础库： `2.22.1`
+       *
+       * 微信小程序：目前 toast 和 loading 相关接口可以相互混用，此参数可用于取消混用特性
+       */
+      noConflict?: boolean
+      /** 接口调用成功的回调函数 */
+      success?: HideToastSuccessCallback
+    }
+  }
+  interface Uni {
+    /**
+     * 隐藏 loading 提示框
+     *
+     * 文档: [http://uniapp.dcloud.io/api/ui/prompt?id=hideloading](http://uniapp.dcloud.io/api/ui/prompt?id=hideloading)
+     * @example ```typescript
+     * uni.showLoading({
+     *   title: '加载中'
+     * });
+     *
+     * setTimeout(function () {
+     *   uni.hideLoading();
+     * }, 2000);
+     *
+     * ```
+     * @tutorial [](https://uniapp.dcloud.net.cn/api/ui/prompt.html#hideloading)
+     * @uniPlatform {
+     * "app": {
+     * "android": {
+     * "osVer": "4.4.4",
+     * "uniVer": "√",
+     * "unixVer": "3.9.0"
+     * },
+     * "ios": {
+     * "osVer": "9.0",
+     * "uniVer": "√",
+     * "unixVer": "3.9.0"
+     * }
+     * }
+     * }
+     */
+    // eslint-disable-next-line ts/method-signature-style
+    hideLoading<T extends UniNamespace.HideToastOption = UniNamespace.HideToastOption>(options?: T): void
+    /**
+     * 隐藏消息提示框
+     *
+     * 文档: [http://uniapp.dcloud.io/api/ui/prompt?id=hidetoast](http://uniapp.dcloud.io/api/ui/prompt?id=hidetoast)
+     * @example ```typescript
+     *    uni.hideToast();
+     * ```
+     * @tutorial [](https://uniapp.dcloud.net.cn/api/ui/prompt.html#hidetoast)
+     * @uniPlatform {
+     * "app": {
+     * "android": {
+     * "osVer": "4.4.4",
+     * "uniVer": "√",
+     * "unixVer": "3.9.0"
+     * },
+     * "ios": {
+     * "osVer": "9.0",
+     * "uniVer": "√",
+     * "unixVer": "3.9.0"
+     * }
+     * }
+     * }
+     */
+    // eslint-disable-next-line ts/method-signature-style
+    hideToast<T extends UniNamespace.HideLoadingOption = UniNamespace.HideLoadingOption>(options?: T): void
+  }
+}
+
 export {} // 防止模块污染


### PR DESCRIPTION
```ts
  try {
    uni.showLoading({
      title: '加载中...',
    })

    // 调用接口
    await new Promise(resolve => setTimeout(resolve, 1000))

    uni.showToast({
      title: '加载完成',
      icon: 'success',
      duration: 1000 * 5,
    })
  }
  catch (err) {
    console.error(err)
  }
  finally {
    uni.hideLoading()
  }
```

在微信小程序真机环境下，如果 `showToast` 后马上运行 `hideLoading`, toast 也会被 hide. 如果想 toast 正常显示，需要这样使用：

```ts
uni.hideLoading({
  noConflict: true,
})
```

但 uniapp 的类型并不完善

ps: 类型都是从 `miniprogram-api-typings` 移植过来的