### PR TITLE
修改命令dev = "node  --import=./scripts/window-path-loader.js node_modules/@dcloudio/vite-plugin-uni/bin/uni.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dev:app-android": "uni -p app-android",
     "dev:app-ios": "uni -p app-ios",
     "dev:custom": "uni -p",
-    "dev": "node --experimental-loader ./scripts/window-path-loader.js node_modules/@dcloudio/vite-plugin-uni/bin/uni.js",
+    "dev": "node  --import=./scripts/window-path-loader.js node_modules/@dcloudio/vite-plugin-uni/bin/uni.js",
     "dev:test": "uni --mode test",
     "dev:prod": "uni --mode production",
     "dev:h5": "uni",


### PR DESCRIPTION
修复命令行执行pnpm run dev:h5 控制台报Waring【(node:6335) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`: --import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("./scripts/window-path-loader.js", pathToFileURL("./"));' (Use `node --trace-warnings ...` to show where the warning was created)】的问题；

警告提示说`--experimental-loader`是一个实验性功能，建议替换成`--import=`
<img width="1173" height="659" alt="image" src="https://github.com/user-attachments/assets/e319be65-e397-4fca-8575-5af16652a09b" />
