### PR TITLE
fix(useRequest): 修复立即执行时参数类型不匹配的问题

### DIFF
--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -48,7 +48,7 @@ export default function useRequest<T, P = undefined>(
   }
 
   if (options.immediate) {
-    (run as (args: P) => Promise<T | undefined>)({} as P)
+    (run as (args?: P) => Promise<T | undefined>)({} as P)
   }
   return { loading, error, data, run }
 }


### PR DESCRIPTION
将run函数的参数类型从必选改为可选，以匹配立即执行时传入空对象的场景